### PR TITLE
fetch settings bean before caches are created to honour disableCache …

### DIFF
--- a/simple-spring-memcached/src/main/java/com/google/code/ssm/DisabledCacheInvocationHandler.java
+++ b/simple-spring-memcached/src/main/java/com/google/code/ssm/DisabledCacheInvocationHandler.java
@@ -36,6 +36,8 @@ public class DisabledCacheInvocationHandler implements InvocationHandler {
     private final String cacheName;
 
     private final Collection<String> cacheAliases;
+    
+    private final CacheProperties cacheProperties = new CacheProperties();
 
     public DisabledCacheInvocationHandler(String cacheName, Collection<String> cacheAliases) {
         this.cacheName = cacheName;
@@ -53,10 +55,12 @@ public class DisabledCacheInvocationHandler implements InvocationHandler {
         } else if ("isEnabled".equals(methodName)) {
             return false;
         } else if ("shutdown".equals(methodName)) {
-            return null;
-        }
+            return null;        
+        } else if("getProperties".equals(methodName)){
+        	return cacheProperties;
+        }        	
 
-        throw new IllegalStateException(String.format("Cache with name %s and aliases %s is disabled", cacheName, cacheAliases));
+        throw new IllegalStateException(String.format("Cache with name %s and aliases %s is disabled for method %s", cacheName, cacheAliases,methodName));
     }
 
 }

--- a/simple-spring-memcached/src/main/java/com/google/code/ssm/aop/CacheBase.java
+++ b/simple-spring-memcached/src/main/java/com/google/code/ssm/aop/CacheBase.java
@@ -73,15 +73,15 @@ public class CacheBase implements ApplicationContextAware, InitializingBean {
 
     @Override
     public void afterPropertiesSet() throws Exception {
-        for (Cache cache : context.getBeansOfType(Cache.class).values()) {
-            addCache(cache);
-        }
-
-        try {
+    	try {
             settings = context.getBean(Settings.class);
         } catch (NoSuchBeanDefinitionException ex) {
             LOG.info("Cannot obtain custom SSM settings, default is used");
         }
+    	
+        for (Cache cache : context.getBeansOfType(Cache.class).values()) {
+            addCache(cache);
+        }        
     }
 
     @Override

--- a/simple-spring-memcached/src/test/java/com/google/code/ssm/SettingsTest.java
+++ b/simple-spring-memcached/src/test/java/com/google/code/ssm/SettingsTest.java
@@ -1,0 +1,48 @@
+package com.google.code.ssm;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+import com.google.code.ssm.Settings;
+import com.google.code.ssm.aop.CacheBase;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SettingsTest {
+	
+    @Mock
+    private Settings globalSSMSettings;
+    
+    @Mock
+    private ApplicationContext applicationContext;
+    
+    @InjectMocks
+    private CacheBase cacheBase = new CacheBase();
+    
+    @Before    
+    public void init(){        
+    	when(applicationContext.getBean(Settings.class)).thenReturn(globalSSMSettings);
+    	cacheBase.setApplicationContext(applicationContext);
+
+    }
+    
+    @Test
+    public void testCacheSettingDisabled() throws Exception {
+    	when(globalSSMSettings.isDisableCache()).thenReturn(true);    	
+    	cacheBase.afterPropertiesSet();
+    	assertEquals(cacheBase.isCacheDisabled(),true);
+    }
+    
+    @Test
+    public void testCacheEnabled() throws Exception {
+    	when(globalSSMSettings.isDisableCache()).thenReturn(false);
+    	cacheBase.afterPropertiesSet();
+    	assertEquals(cacheBase.isCacheDisabled(),false);
+    }
+}

--- a/spring-cache-integration-test/src/main/resources/application-context.xml
+++ b/spring-cache-integration-test/src/main/resources/application-context.xml
@@ -85,21 +85,8 @@
 		<property name="defaultSerializationType"
 			value="#{T(com.google.code.ssm.api.format.SerializationType).valueOf(@defaultSerializationTypeAsString)}" />
 	</bean>
-	
-	
-	<!-- flush all data from memcached before starting tests -->
-	<bean id="flushUserCache" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
-		<property name="targetObject" ref="userCache" />
-		<property name="targetMethod" value="flush" />
-	</bean>
-
-	<!-- flush all data from memcached before starting tests -->
-	<bean id="flushClearableCache" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
-		<property name="targetObject" ref="clearableCache" />
-		<property name="targetMethod" value="flush" />
-	</bean>
-	
-		<beans profile="xmemcached">
+		
+	<beans profile="xmemcached">
 		<bean name="cacheClientFactory" class="com.google.code.ssm.providers.xmemcached.MemcacheClientFactoryImpl" />
 		<bean name="clientConfig" class="com.google.code.ssm.providers.CacheConfiguration">
 			<property name="consistentHashing" value="true" />

--- a/spring-cache-integration-test/src/main/resources/flush-cache-beans.xml
+++ b/spring-cache-integration-test/src/main/resources/flush-cache-beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context" xmlns:cache="http://www.springframework.org/schema/cache"
+	xsi:schemaLocation="
+		   http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+           http://www.springframework.org/schema/context
+           http://www.springframework.org/schema/context/spring-context-3.1.xsd
+           http://www.springframework.org/schema/cache 
+           http://www.springframework.org/schema/cache/spring-cache-3.1.xsd">
+	
+	<!-- flush all data from memcached before starting tests -->
+	<bean id="flushUserCache" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" depends-on="userCache">
+		<property name="targetObject" ref="userCache" />
+		<property name="targetMethod" value="flush" />
+	</bean>
+
+	<!-- flush all data from memcached before starting tests -->
+	<bean id="flushClearableCache" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+		<property name="targetObject" ref="clearableCache" />
+		<property name="targetMethod" value="flush" />
+	</bean>
+	
+</beans>

--- a/spring-cache-integration-test/src/test/java/com/google/code/ssm/spring/test/DisabledCacheTest.java
+++ b/spring-cache-integration-test/src/test/java/com/google/code/ssm/spring/test/DisabledCacheTest.java
@@ -17,7 +17,6 @@
 
 package com.google.code.ssm.spring.test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -26,15 +25,11 @@ import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import com.google.code.ssm.Cache;
-import com.google.code.ssm.CacheFactory;
-import com.google.code.ssm.aop.support.PertinentNegativeNull;
 import com.google.code.ssm.providers.CacheException;
 import com.google.code.ssm.spring.test.dao.AppUserDAO;
 import com.google.code.ssm.spring.test.entity.AppUser;
@@ -48,60 +43,25 @@ import com.google.code.ssm.spring.test.entity.AppUserPK;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @TestExecutionListeners({ DependencyInjectionTestExecutionListener.class })
-@ContextConfiguration(locations = { "classpath*:simplesm-context.xml", "classpath*:application-context.xml","classpath*:flush-cache-beans.xml" })
-public class CacheTest {
+@ContextConfiguration(locations = { "classpath*:simplesm-context.xml", "classpath*:application-context.xml","classpath*:cache-disabled-setting.xml" })
+public class DisabledCacheTest {
 
     @Autowired
     private AppUserDAO dao;
-
-    @Autowired
-    @Qualifier("userCache")
-    private Cache userCache;
-
-    @Autowired
-    @Qualifier("clearableCache")
-    private Cache clearableCache;
-
-    @Autowired
-    @Qualifier("userCache")
-    private CacheFactory userCacheFactory;
-
-    @Autowired
-    @Qualifier("clearableCache")
-    private CacheFactory clearableCacheFactory;
-
+    
     @Test
     public void test() throws TimeoutException, CacheException {
         AppUserPK pk = new AppUserPK(1, 2);
         AppUser appUser = new AppUser(pk);
-
         dao.create(appUser);
-
-        check(appUser.getPK(), appUser);
-
         appUser.setEnabled(false);
         dao.update(appUser);
-
-        check(appUser.getPK(), appUser);
-
-        dao.remove(appUser.getPK());
-
-        check(appUser.getPK(), null);
-        check(appUser.getPK(), null);
+        dao.remove(appUser.getPK());        
     }
+
 
     @Test
-    public void validClearAll() throws TimeoutException, CacheException {
-        String key = "test-key";
-        clearableCache.set(key, 10, "test-value", clearableCacheFactory.getDefaultSerializationType());
-        assertNotNull(clearableCache.get(key, clearableCacheFactory.getDefaultSerializationType()));
-
-        dao.removeAllFromCache();
-        assertNull(clearableCache.get(key, clearableCacheFactory.getDefaultSerializationType()));
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void invalidClearAll() {
+    public void validClearAll() {
         AppUserPK pk = new AppUserPK(10, 340);
         try {
             dao.create(new AppUser(pk));
@@ -109,21 +69,7 @@ public class CacheTest {
 
             dao.removeAllUsers();
         } finally {
-            assertNotNull(dao.getByPk(pk));
+            assertNull(dao.getByPk(pk));
         }
     }
-
-    private void check(final AppUserPK pk, final AppUser target) throws TimeoutException, CacheException {
-        AppUser au;
-        au = getResult(userCache.get(pk.cacheKey(), userCacheFactory.getDefaultSerializationType()));
-        assertEquals(target, au);
-
-        au = dao.getByPk(pk);
-        assertEquals(target, au);
-    }
-
-    private AppUser getResult(final Object result) {
-        return (result instanceof PertinentNegativeNull) ? null : (AppUser) result;
-    }
-
 }

--- a/spring-cache-integration-test/src/test/resources/cache-disabled-setting.xml
+++ b/spring-cache-integration-test/src/test/resources/cache-disabled-setting.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context" xmlns:cache="http://www.springframework.org/schema/cache"
+	xsi:schemaLocation="
+		   http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+           http://www.springframework.org/schema/context
+           http://www.springframework.org/schema/context/spring-context-3.1.xsd
+           http://www.springframework.org/schema/cache 
+           http://www.springframework.org/schema/cache/spring-cache-3.1.xsd">
+	
+	<bean name="globalSSMSettings" class="com.google.code.ssm.Settings">
+   		<property name="disableCache" value="true"/>
+ 	</bean>	
+</beans>


### PR DESCRIPTION
Pull request for #48.
Changed  the order of querying so that settings bean is queried before caches are created.
Added unit tests as well for this behavior.