### PR TITLE
Return cache object on subsequent calls to CacheFactory::getObject()

### DIFF
--- a/simple-spring-memcached/src/main/java/com/google/code/ssm/CacheFactory.java
+++ b/simple-spring-memcached/src/main/java/com/google/code/ssm/CacheFactory.java
@@ -128,7 +128,7 @@ public class CacheFactory implements AddressChangeListener, FactoryBean<Cache>, 
 
     @Override
     public Cache getObject() throws Exception {
-        return createCache();
+        return (cache != null) ? cache : createCache();
     }
 
     @Override


### PR DESCRIPTION
When using `CacheFactory` in a parent / child applicationContext setup, `CacheFactory::getObject()` can be called multiple times despite `isSingleton()` being true leading to `createCache()` throwing `IllegalStateException`