### PR TITLE
Adding sslContext support to elasticache configuration.

### DIFF
--- a/aws-elasticache-provider/src/main/java/com/google/code/ssm/providers/elasticache/ElastiCacheConfiguration.java
+++ b/aws-elasticache-provider/src/main/java/com/google/code/ssm/providers/elasticache/ElastiCacheConfiguration.java
@@ -19,6 +19,8 @@ package com.google.code.ssm.providers.elasticache;
 
 import java.util.Collection;
 
+import javax.net.ssl.SSLContext;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import net.spy.memcached.ConnectionFactoryBuilder;
@@ -151,5 +153,11 @@ public class ElastiCacheConfiguration extends CacheConfiguration {
      * @since 4.0.0
      */
     private MetricCollector metricCollector;
+
+    private SSLContext sslContext;
+
+    private String hostnameForTlsVerification;
+
+    private Boolean skipTlsHostnameVerification;
 
 }

--- a/aws-elasticache-provider/src/main/java/com/google/code/ssm/providers/elasticache/MemcacheClientFactoryImpl.java
+++ b/aws-elasticache-provider/src/main/java/com/google/code/ssm/providers/elasticache/MemcacheClientFactoryImpl.java
@@ -158,6 +158,18 @@ public class MemcacheClientFactoryImpl implements CacheClientFactory {
         if (conf.getMetricCollector() != null) {
             builder.setMetricCollector(conf.getMetricCollector());
         }
+        
+        if (conf.getSslContext() != null) {
+            builder.setSSLContext(conf.getSslContext());
+        }
+        
+        if (conf.getHostnameForTlsVerification() != null) {
+            builder.setHostnameForTlsVerification(conf.getHostnameForTlsVerification());
+        }
+        
+        if (conf.getSkipTlsHostnameVerification() != null) {
+            builder.setSkipTlsHostnameVerification(conf.getSkipTlsHostnameVerification());
+        }
 
     }
 

--- a/aws-elasticache-provider/src/test/java/com/google/code/ssm/providers/elasticache/MemcacheClientFactoryImplTest.java
+++ b/aws-elasticache-provider/src/test/java/com/google/code/ssm/providers/elasticache/MemcacheClientFactoryImplTest.java
@@ -23,15 +23,13 @@ import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 
-import net.spy.memcached.FailureMode;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import com.google.code.ssm.providers.CacheClient;
 import com.google.code.ssm.providers.CacheConfiguration;
-import com.google.code.ssm.providers.elasticache.MemcacheClientFactoryImpl;
-import com.google.code.ssm.providers.elasticache.ElastiCacheConfiguration;
+
+import net.spy.memcached.FailureMode;
 
 /**
  * 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<jackson.version>2.9.9</jackson.version>
 		<spymemcached.version>2.12.3</spymemcached.version>
 		<xmemcached.version>2.4.6</xmemcached.version>
-		<elasticache.version>1.1.1</elasticache.version>
+		<elasticache.version>1.2.0</elasticache.version>
 		<slf4j.version>1.6.4</slf4j.version>
 		<apiviz.version>1.3.4</apiviz.version>
 		<lombok.version>1.16.18</lombok.version>


### PR DESCRIPTION
These changes will allow for sslContext to be added to the connectionFactory based on the changes in 1.2.0 of elasticache-java-cluster-client library.  Tested this works locally with my project.  Was not able to add testing at this time.